### PR TITLE
turn back a NULL format to develop

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -9,11 +9,14 @@ int _printf(const char *format, ...)
 {
 	int (*f)(va_list);
 	va_list list;
-	int l = -1;
+	int l = 0;
+
+	if (!format)
+		return (-1);
 
 	va_start(list, format);
 
-	while (format && *format)
+	while (*format)
 	{
 		if (*format != '%')
 			l += _putchar(*format);

--- a/_printf.c
+++ b/_printf.c
@@ -9,11 +9,11 @@ int _printf(const char *format, ...)
 {
 	int (*f)(va_list);
 	va_list list;
-	int l = 0;
+	int l = -1;
 
 	va_start(list, format);
 
-	while (*format)
+	while (format && *format)
 	{
 		if (*format != '%')
 			l += _putchar(*format);


### PR DESCRIPTION
- [x] the NULL format feature was implemented in the masters. Were copying it to develop